### PR TITLE
:require in ns definition

### DIFF
--- a/src/com/billpiel/sayid/inner_trace2.clj
+++ b/src/com/billpiel/sayid/inner_trace2.clj
@@ -1,6 +1,6 @@
 (ns com.billpiel.sayid.inner-trace2
-  (require [com.billpiel.sayid.util.other :as util]
-           [com.billpiel.sayid.trace :as trace]))
+  (:require [com.billpiel.sayid.util.other :as util]
+            [com.billpiel.sayid.trace :as trace]))
 
 (defn prs
   [v]

--- a/src/com/billpiel/sayid/profiling.clj
+++ b/src/com/billpiel/sayid/profiling.clj
@@ -1,7 +1,7 @@
 (ns com.billpiel.sayid.profiling
-  (require [com.billpiel.sayid.trace :as tr]
-           [com.billpiel.sayid.recording :as rec]
-           [com.billpiel.sayid.util.other :as util]))
+  (:require [com.billpiel.sayid.trace :as tr]
+            [com.billpiel.sayid.recording :as rec]
+            [com.billpiel.sayid.util.other :as util]))
 
 (defn merge-profile-values
   [a b]

--- a/src/com/billpiel/sayid/query2.clj
+++ b/src/com/billpiel/sayid/query2.clj
@@ -1,7 +1,6 @@
 (ns com.billpiel.sayid.query2
-  (require [clojure.zip :as z]
-           [com.billpiel.sayid.util.other :as util]
-           ))
+  (:require [clojure.zip :as z]
+            [com.billpiel.sayid.util.other :as util]))
 
 ;; === zipper iterators
 

--- a/src/com/billpiel/sayid/trace.clj
+++ b/src/com/billpiel/sayid/trace.clj
@@ -1,5 +1,5 @@
 (ns com.billpiel.sayid.trace
-  (require [com.billpiel.sayid.util.other :as util]))
+  (:require [com.billpiel.sayid.util.other :as util]))
 
 
 (def ^:dynamic *trace-log-parent* nil)

--- a/src/com/billpiel/sayid/util/other.clj
+++ b/src/com/billpiel/sayid/util/other.clj
@@ -1,8 +1,8 @@
 (ns com.billpiel.sayid.util.other
-  (require [clojure.walk :as walk]
-           [clojure.tools.reader :as r]
-           [clojure.tools.reader.reader-types :as rts]
-           clojure.repl))
+  (:require [clojure.walk :as walk]
+            [clojure.tools.reader :as r]
+            [clojure.tools.reader.reader-types :as rts]
+            clojure.repl))
 
 (defn ->int
   [v]

--- a/src/com/billpiel/sayid/util/tree_query.clj
+++ b/src/com/billpiel/sayid/util/tree_query.clj
@@ -1,6 +1,6 @@
 (ns com.billpiel.sayid.util.tree-query
-  (require [clojure.zip :as z]
-           [swiss.arrows :refer [-<> -<>>]]))
+  (:require [clojure.zip :as z]
+            [swiss.arrows :refer [-<> -<>>]]))
 
 (def ^:dynamic *get-tags-mz* nil)
 

--- a/test/com/billpiel/sayid/test/ns1.clj
+++ b/test/com/billpiel/sayid/test/ns1.clj
@@ -1,5 +1,5 @@
 (ns com.billpiel.sayid.test.ns1
-  (require [com.billpiel.sayid.util.other :refer [$-]]))
+  (:require [com.billpiel.sayid.util.other :refer [$-]]))
 
 (defn func2
   [arg1]


### PR DESCRIPTION
Preparing for clojure 1.9, which throws an error when not using the keyword style of require.
In addition, the tamarin dependency will have to be updated to a version that fixes this same issue in its repository.