### PR TITLE
Auto inject depencencies at cider-jack-in time

### DIFF
--- a/src/el/sayid.el
+++ b/src/el/sayid.el
@@ -33,6 +33,11 @@
 
 (require 'cider)
 
+(defcustom sayid-inject-dependencies-at-jack-in t
+  "When nil, do not inject repl dependencies (most likely nREPL middlewares) at `cider-jack-in' time."
+  :group 'sayid
+  :type 'boolean)
+
 (defvar sayid-version-)
 (setq sayid-version- "0.0.15")
 
@@ -46,6 +51,21 @@
 
 (defvar sayid-ring)
 (setq sayid-ring '())
+
+
+;;;###autoload
+(defun sayid--inject-jack-in-dependencies ()
+  "Inject the REPL dependencies of sayid at `cider-jack-in'.
+If injecting the dependencies is not preferred set `sayid-inject-dependencies-at-jack-in' to nil."
+  (when (and sayid-inject-dependencies-at-jack-in
+             (boundp 'cider-jack-in-lein-plugins)
+             (boundp 'cider-jack-in-nrepl-middlewares))
+    (add-to-list 'cider-jack-in-lein-plugins `("com.billpiel/sayid" ,sayid-version-))
+    (add-to-list 'cider-jack-in-nrepl-middlewares "com.billpiel.sayid.nrepl-middleware/wrap-sayid")))
+
+;;;###autoload
+(eval-after-load 'cider
+  '(sayid--inject-jack-in-dependencies))
 
 ;;;###autoload
 (defun sayid-version ()


### PR DESCRIPTION
Follow suit of newer versions of cider and related
projects (clj-refactor, company etc) in terms of injecting their own
middleware dependencies using the command line when you jack-in. So
you don't need to modify your `.lein/profiles.clj` anymore (unless you
use `cider-connect` instead of jacking in).

Defcustom is added too so opting out of this behaviour is easy.

supposed to work with `boot` too but only tested with `lein`.

Related piece of cider documentation: https://cider.readthedocs.io/en/latest/installation/ section `CIDER's nREPL middleware`.